### PR TITLE
Default log file for Debian

### DIFF
--- a/data/fail2ban/osfamily/Debian.yaml
+++ b/data/fail2ban/osfamily/Debian.yaml
@@ -2,3 +2,4 @@
   fail2ban::settings:
     init_file_path: '/etc/default/fail2ban'
     pid_file_path: '/var/run/fail2ban/fail2ban.pid'
+    log_file_path: '/var/log/fail2ban.log'


### PR DESCRIPTION
The default log file for Debian (wheezy+) is defined in fail2ban.conf as follows

```
# Option:  logtarget
# Notes.:  Set the log target. This could be a file, SYSLOG, STDERR or STDOUT.
#          Only one log target can be specified.
# Values:  STDOUT STDERR SYSLOG file  Default:  /var/log/fail2ban.log
#
logtarget = /var/log/fail2ban.log
```