### PR TITLE
change package_name to vim because vim-common doesn't install vim only

### DIFF
--- a/data/vim/default.yaml
+++ b/data/vim/default.yaml
@@ -1,5 +1,5 @@
 ---
   vim::settings:
-    package_name: 'vim-common'
+    package_name: 'vim'
     config_file_path: '/etc/vim/vimrc'
     config_dir_path: '/etc/vim'


### PR DESCRIPTION
The vim-common is a dependency for vim.