### PR TITLE
Debian 9: samba.service is masked

### DIFF
--- a/data/samba/hiera.yaml
+++ b/data/samba/hiera.yaml
@@ -1,5 +1,6 @@
 ---
 :hierarchy:
+  - "%{title}/operatingsystem/%{operatingsystem}%{operatingsystemmajrelease}"
   - "%{title}/osfamily/%{osfamily}"
   - "%{title}/default"
   - "default/%{operatingsystem}"

--- a/data/samba/operatingsystem/Debian9.yaml
+++ b/data/samba/operatingsystem/Debian9.yaml
@@ -1,0 +1,3 @@
+---
+  samba::settings:
+    service_name: 'smb'


### PR DESCRIPTION
Debian 9 is using systemd. `samba.service` is masked. Therefore restarting the service will fail.