### PR TITLE
Adding file path configuration puppetdb.conf

### DIFF
--- a/data/puppet-agent/default.yaml
+++ b/data/puppet-agent/default.yaml
@@ -7,6 +7,7 @@
     routes_file_path: '/etc/puppetlabs/puppet/routes.yaml'
     autosign_file_path: '/etc/puppetlabs/puppet/autosign.conf'
     auth_file_path: '/etc/puppetlabs/puppet/auth.conf'
+    puppetdb_file_path: '/etc/puppetlabs/puppet/puppetdb.conf'
     config_dir_path: '/etc/puppetlabs/puppet/'
     code_dir_path: '/etc/puppetlabs/code'
     environment_dir_path: '/etc/puppetlabs/code/environments'


### PR DESCRIPTION
When using puppetdb in the puppet-agent configuration path we need a file called puppetdb.conf. Since there are also mappings for eg. file routes.yaml I thing it makes sense to add this also.

