### PR TITLE
debian9 jre/jdk package fix (issue 34)

### DIFF
--- a/data/openjdk-jdk/operatingsystem/Debian9.yaml
+++ b/data/openjdk-jdk/operatingsystem/Debian9.yaml
@@ -1,0 +1,3 @@
+---
+  openjdk-jdk::settings:
+    package_name: 'openjdk-8-jdk'

--- a/data/openjdk-jre/operatingsystem/Debian9.yaml
+++ b/data/openjdk-jre/operatingsystem/Debian9.yaml
@@ -1,0 +1,3 @@
+---
+  openjdk-jre::settings:
+    package_name: 'openjdk-8-jre-headless'


### PR DESCRIPTION
Added the correct jre/jdk for Debian9.
Placed them under operatingsystem.

## Before submitting your PR
This is a fix for issue 34 (Debian 9 jdk/jre package wrong)
