### PR TITLE
Change default path for RedHat

### DIFF
--- a/data/multipath/osfamily/RedHat.yaml
+++ b/data/multipath/osfamily/RedHat.yaml
@@ -3,3 +3,4 @@
     package_name: 'device-mapper-multipath'
     service_name: 'multipathd'
     init_file_path: '/etc/sysconfig/multipath'
+    config_file_path: '/etc/multipath.conf'


### PR DESCRIPTION
The path for RedHat must '/etc/multipath.conf'

## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

