### PR TITLE
debian11 iptraf pkg is called iptraf-ng #43

### DIFF
--- a/data/iptraf/hiera.yaml
+++ b/data/iptraf/hiera.yaml
@@ -1,5 +1,7 @@
 ---
 :hierarchy:
+  - "%{title}/operatingsystem/%{operatingsystem}-%{operatingsystemrelease}"
+  - "%{title}/operatingsystem/%{operatingsystem}"
   - "%{title}/osfamily/%{osfamily}"
   - "%{title}/default"
   - "default/%{operatingsystem}"

--- a/data/iptraf/operatingsystem/Debian-11.yaml
+++ b/data/iptraf/operatingsystem/Debian-11.yaml
@@ -1,0 +1,3 @@
+---
+  iptraf::settings:
+    package_name: 'iptraf-ng'


### PR DESCRIPTION
## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

