### PR TITLE
fix to check on major os release version only #43

### DIFF
--- a/data/iptraf/hiera.yaml
+++ b/data/iptraf/hiera.yaml
@@ -1,6 +1,6 @@
 ---
 :hierarchy:
-  - "%{title}/operatingsystem/%{operatingsystem}-%{operatingsystemrelease}"
+  - "%{title}/operatingsystem/%{operatingsystem}-%{operatingsystemmajrelease}"
   - "%{title}/operatingsystem/%{operatingsystem}"
   - "%{title}/osfamily/%{osfamily}"
   - "%{title}/default"


### PR DESCRIPTION
Found an error in the OS version check. Now it only uses the major release number to find hiera data.