### PR TITLE
squid with debian 12 has now a conf.d dir

### DIFF
--- a/data/squid/default.yaml
+++ b/data/squid/default.yaml
@@ -4,6 +4,7 @@ squid::settings:
   service_name: 'squid'
   config_file_path: '/etc/squid/squid.conf'
   config_dir_path: '/etc/squid'
+  conf_dir_path: '/etc/squid/conf.d'
   pid_file_path: '/var/run/squid.pid'
   process_name: 'squid'
   process_user: 'squid'


### PR DESCRIPTION
squid in Debian Bookworm (12) has now a conf.d directory.
